### PR TITLE
getCatalog() now gets the whole catalog as promise

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -87,7 +87,7 @@
                 </div>
             </div>
             <button class="btn" type='button' onclick="testAuth()">TEST AUTH</button>
-            <button class="btn" type='button' onclick="getCatalog(); false;">LOAD CATALOG</button>
+            <button class="btn" type='button' onclick="testGetCatalog(); false;">LOAD CATALOG</button>
         </div>
     </body>
 </html>

--- a/src/browse.js
+++ b/src/browse.js
@@ -1,3 +1,15 @@
+/**
+ * browse.js
+ * FilmList Project
+ * Software Engineering Class
+ * Teacher: Carol Redfield
+ * Programmers: Richard, Matt, Jeremy, Catherine, Colin, Manny
+ * What's in this file: 
+ *      Code for getting movies from the OMDB API
+ *      Code for displaying the results pulled from the OMDB. 
+ *      Code for adding movies to the google Firebase Database
+ */
+
 /* enables searching of movies from OMDb */
 var endpoint = 'http://www.omdbapi.com/';
 var apiKey = 'd0507337';
@@ -344,9 +356,21 @@ function resizeImageTo(src, newHeight) {
 
 //adds the specified movie to the user's catalog
 function addToCatalog(el){
-    addMovieToDocStore(el, 'catalog', 'catalog');
+    addMovieToDocStore(el, 0);
 }
 
+function addToQueue(el) {
+    addMovieToDocStore(el, 2);
+}
+
+/**
+ *          
+ * @param {*} el    The button element
+ * @param {*} state State is the storage state of the document to be saved. 
+ *                  0: Catalog
+ *                  1: Both Catalog and Queue
+ *                  2: Queue
+ */         
 function addMovieToDocStore(el, state) {
     console.log("Adding movie info with state " + state);
     var data = JSON.parse(el.getAttribute("data-imdb"));
@@ -358,9 +382,12 @@ function addMovieToDocStore(el, state) {
         if (doc.exists) {
             console.log("Document exists, updating");
             dataState = doc.data().state;
-            if((dataState == "catalog" && state == "queue") || (dataState == "queue" && state == "catalog") || (dataState == "both")){
+            //      if current state of the document is catalog and the incoming state is queue
+            //OR    if current state of the document is queue and the incoming state is catalog
+            //OR    if current state of the document is already both
+            if((dataState == 0 && state == 2) || (dataState == 2 && state == 0) || (dataState == 1)){
                 console.log("Updating to \"both\"");
-                data['state'] = "both"
+                data['state'] = 1
             }
             users.doc(docId).update(data);
         } else {
@@ -376,9 +403,6 @@ function removeFromCatalog(el) {
     console.log("TODO: removing from catalog");
 }
 
-function addToQueue(el) {
-    addMovieToDocStore(el, 'queue', 'queue');
-}
 function removeFromQueue(el) {
     console.log("TODO: removing from queue");
 }

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -16,28 +16,46 @@ function testAuth(){
     }
 }
 
+function testGetCatalog(){
+    var catalogQ = getCatalog();
+
+    var test = arrayify(catalogQ);
+
+    consoleOutputPromiseArray(test);
+
+    //console.log("Outputting a filtered query. ");
+    //consoleOutputPromiseArray(arrayify(filterYear(catalogQ, "1938")));
+    
+}
+
 function getCatalog(){
     var db = firebase.firestore();
     var users = db.collection("users");
     var collectionId = "users/"+firebase.auth().currentUser.uid+"/movies";
     var movies = db.collection(collectionId);
-    var test = movies.where("state", "<=", 1).get()
-        .then(function(snapshot){
-            var ary = [];
-            snapshot.forEach(function(doc){
-                ary.push(doc.data());
-            });
-            return ary;
-        }).catch(function(error){
-            console.log("Error getting doc: ", error);
-        });
-    console.log(test);
+    return movies.where("state", "<=", 1).where("year", "==", "1938");
+}
 
-    test.then(function(ary){
+function filterYear(query, year){
+    return query.where("year", "==", year);
+}
+
+function arrayify(query){
+    return query.get().then(function(snapshot){
+        var ary = [];
+        snapshot.forEach(function(doc){
+            ary.push(doc.data());
+        });
+        return ary;
+    }).catch(function(error){
+        console.log("Error getting doc: ", error);
+    });
+}
+
+function consoleOutputPromiseArray(promiseArray){
+    promiseArray.then(function(ary){
         for(var i=0; i < ary.length; i++){
             console.log(ary[i]);
         }
     });
-
-    return test;
 }

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -1,3 +1,15 @@
+/**
+ * browse.js
+ * FilmList Project
+ * Software Engineering Class
+ * Teacher: Carol Redfield
+ * Programmers: Richard, Matt, Jeremy, Catherine, Colin, Manny
+ * What's in this file: 
+ *      Code for getting movies from the OMDB API
+ *      Code for displaying the results pulled from the OMDB. 
+ *      Code for adding movies to the google Firebase Database
+ */
+
 function testAuth(){
     if (firebase.auth().currentUser !== null) {
         console.log("user id: " + firebase.auth().currentUser.uid);
@@ -7,15 +19,25 @@ function testAuth(){
 function getCatalog(){
     var db = firebase.firestore();
     var users = db.collection("users");
-    var docId = ""+firebase.auth().currentUser.uid+"-catalog";
-    users.doc(docId).get().then(function(doc) {
-        if (doc.exists) {
-            console.log("Document data:", doc.data());
-        } else {
-            // doc.data() will be undefined in this case
-            console.log("No such document!");
+    var collectionId = "users/"+firebase.auth().currentUser.uid+"/movies";
+    var movies = db.collection(collectionId);
+    var test = movies.where("state", "<=", 1).get()
+        .then(function(snapshot){
+            var ary = [];
+            snapshot.forEach(function(doc){
+                ary.push(doc.data());
+            });
+            return ary;
+        }).catch(function(error){
+            console.log("Error getting doc: ", error);
+        });
+    console.log(test);
+
+    test.then(function(ary){
+        for(var i=0; i < ary.length; i++){
+            console.log(ary[i]);
         }
-    }).catch(function(error) {
-        console.log("Error getting document:", error);
     });
+
+    return test;
 }


### PR DESCRIPTION
the getCatalog() function in catalog.js now will return a Promise that contains the array of JSONs that comprise the movies that are in the catalog and in both the catalog and the queue. There's an example of how to access the array inside the function itself. 

Something that would be useful is to change the code so that the getCatalog() returns a promise containing the Query, and provide functions to extract the data from the query (such as arrayify() for example). This way, the initial getCatalog() can get the original query, which can have other .where() clauses added on, which is useful for filtering.
If we have an arrayify(QuerySnapshot) function, we can arrayify any sub-query that we may construct.
